### PR TITLE
Fix integration with spacy on empty string

### DIFF
--- a/pyvi/ViTokenizer.py
+++ b/pyvi/ViTokenizer.py
@@ -131,7 +131,7 @@ class ViTokenizer:
     def spacy_tokenize(str):
         text, tmp = ViTokenizer.sylabelize(str)
         if len(tmp) == 0:
-            return str
+            return [], []
         labels = ViTokenizer.model.predict([ViTokenizer.sent2features(tmp, False)])
         token = tmp[0]
         tokens = []


### PR DESCRIPTION
spaCy uses the output of `ViTokenizer.spacy_tokenize` as [`words, spaces = ViTokenizer.spacy_tokenize(text)`](https://github.com/explosion/spaCy/blob/master/spacy/lang/vi/__init__.py#L38). When an empty string is passed in, `ViTokenizer.spacy_tokenize` returns an empty string, which makes this part of the code fail with a `ValueError: not enough values to unpack (expected 2, got 0)`.

The fix returns two empty lists instead, which are acceptable by spaCy:

```python
from spacy.tokens import Doc
from spacy import blank
from pyvi import ViTokenizer
nlp = blank("vi")
words, spaces = ViTokenizer.spacy_tokenize("")
Doc(nlp.vocab, words=words, spaces=spaces)
```