### PR TITLE
Fix inconsistent return type from spacy_tokenize for empty strings

### DIFF
--- a/pyvi/ViTokenizer.py
+++ b/pyvi/ViTokenizer.py
@@ -131,7 +131,7 @@ class ViTokenizer:
     def spacy_tokenize(str):
         text, tmp = ViTokenizer.sylabelize(str)
         if len(tmp) == 0:
-            return str
+            return [], []
         labels = ViTokenizer.model.predict([ViTokenizer.sent2features(tmp, False)])
         token = tmp[0]
         tokens = []


### PR DESCRIPTION
The `spacy_tokenize` function normally returns a tuple of lists, with the first element representing the discovered tokens and the second element representing trailing spaces. However, when an empty string is passed to the function, the empty string is returned unchanged. This results in a confusing situation where the return type of `spacy_tokenize` must be checked on every call.

These changes modify `spacy_tokenize` to instead return a tuple of empty lists for the empty string, making its return type consistent regardless of input.