### PR TITLE
KeyError debug for ViDiac.doit (or equiv. ViUtils.add_accent)

### DIFF
--- a/pyvi/ViDiac.py
+++ b/pyvi/ViDiac.py
@@ -169,27 +169,27 @@ class ViDiac:
 
     @staticmethod
     def doit(str_sentence):
-        list_char = list(str_sentence.lower())
-        labels = ViDiac.model.predict([ViDiac.sent2features(list_char)])
+        str_sentence_lower = str_sentence.lower()
+        labels = ViDiac.model.predict([ViDiac.sent2features(str_sentence_lower)])[0]
         output = u''
-        for i in range(len(list_char)):
-            if labels[0][i] == 'L':
-                output += list_char[i]
-            elif labels[0][i] == 'U':
-                output += list_char[i].upper()
+        for char, label in zip(str_sentence_lower, labels):
+            if label == 'L':
+                output += char
+            elif label == 'U':
+                output += char.upper()
             else:
-                upcase = False
-                unichar = list_char[i]
-                for label in labels[0][i]:
-                    if label == 'U':
-                        upcase = True
-                    elif label == 'L':
+                uppercase = False
+                unichar = char
+                for c in label:
+                    if c == 'U':
+                        uppercase = True
+                    elif c == 'L':
                         continue
-                    elif label == 'm':
+                    elif c == 'm':
                         unichar += unichar
                     else:
-                        unichar += label
-                if upcase:
+                        unichar += c
+                if uppercase:
                     unichar = unichar.upper()
                 output += ViDiac.reversed_mapping.get(unichar, unichar[0])
         return output

--- a/pyvi/ViDiac.py
+++ b/pyvi/ViDiac.py
@@ -171,17 +171,13 @@ class ViDiac:
     def doit(str_sentence):
         list_char = list(str_sentence.lower())
         labels = ViDiac.model.predict([ViDiac.sent2features(list_char)])
-        # output = tmp[0]
-        # print labels[0]
         output = u''
         for i in range(len(list_char)):
-            # print list_char[i], labels[0][i]
             if labels[0][i] == 'L':
                 output += list_char[i]
             elif labels[0][i] == 'U':
                 output += list_char[i].upper()
             else:
-                # print "label_{}".format(labels[0][i])
                 upcase = False
                 unichar = list_char[i]
                 for label in labels[0][i]:
@@ -195,8 +191,7 @@ class ViDiac:
                         unichar += label
                 if upcase:
                     unichar = unichar.upper()
-                # print unichar
-                output += ViDiac.reversed_mapping[unichar]
+                output += ViDiac.reversed_mapping.get(unichar, unichar[0])
         return output
 
 def add_accents(s):


### PR DESCRIPTION
Certain sentences one cannot `add_accents` to them, e.g.
```python
In [1]: from pyvi import ViUtils

In [2]: s = "suy nghi rieng"

In [3]: ViUtils.add_accents(s)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[3], line 1
----> 1 ViUtils.add_accents(s)

File ~/.config/miniconda3/envs/fraud/lib/python3.8/site-packages/pyvi/ViUtils.py:22, in add
_accents(s)
     21 def add_accents(s):
---> 22     return ViDiac.add_accents(s)

File ~/.config/miniconda3/envs/fraud/lib/python3.8/site-packages/pyvi/ViDiac.py:203, in add
_accents(s)
    202 def add_accents(s):
--> 203     return ViDiac.doit(s)

File ~/.config/miniconda3/envs/fraud/lib/python3.8/site-packages/pyvi/ViDiac.py:199, in ViD
iac.doit(str_sentence)
    197             unichar = unichar.upper()
    198         # print unichar
--> 199         output += ViDiac.reversed_mapping[unichar]
    200 return output

KeyError: 'ewx'
```
If one **reads into the source code** or **tries to debug** (say, using `ipdb`),
one'd find the cause being that the dictionary
`ViDiac.reversed_mapping` lacks certain keys that `label` could produce.

W/o diving into the inner working and design of the code, a quick bug fix could
be
```python
output += ViDiac.reversed_mapping.get(unichar, unichar[0])
```
After such modification, we'd obtain
```python
In [1]: from pyvi import ViDiac
                                                                                            
In [2]: ViDiac.ViDiac.doit("suy nghi rieng")
Out[2]: 'Suy nghi rieng'

In [3]: ViDiac.ViDiac.doit("suy nghi")
Out[3]: 'Suy nghi'

In [4]: ViDiac.ViDiac.doit("Mot nguoi co suy nghi.")
Out[4]: 'Một người có suy nghĩ.'
```